### PR TITLE
abaplint: disable unknown_types

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -313,7 +313,7 @@
       "exclude": [],
       "pattern": "^(L?TY|T.{1,2})_.+$"
     },
-    "unknown_types": true,
+    // "unknown_types": true,
     "unreachable_code": true,
     "unused_variables": false,
     "use_new": true,


### PR DESCRIPTION
disable unknown_types, it doesnt work very well if there are syntax errors